### PR TITLE
infra/update-vst2: migrate to vst2 v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please, note that since `phono` is in active development stage, all packages are
 
 `phono/vst2` and `portaudio` packages do have external non-go dependencies. To use these packages, please check the documentation:
 
-* [vst2](https://github.com/dudk/vst2#dependencies)
+* [vst2](https://github.com/pipelined/vst2#dependencies)
 * [portaudio](https://github.com/gordonklaus/portaudio#portaudio)
 
 ## Testing

--- a/_example/example2.go
+++ b/_example/example2.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pipelined/phono/test"
 	"github.com/pipelined/phono/vst2"
 	"github.com/pipelined/phono/wav"
-	vst2sdk "github.com/dudk/vst2"
+	vst2sdk "github.com/pipelined/vst2"
 )
 
 // Example:

--- a/_example/example5.go
+++ b/_example/example5.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pipelined/phono/test"
 	"github.com/pipelined/phono/vst2"
 	"github.com/pipelined/phono/wav"
-	vst2sdk "github.com/dudk/vst2"
+	vst2sdk "github.com/pipelined/vst2"
 )
 
 // Example:

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/pipelined/phono
 
 require (
-	github.com/dudk/vst2 v0.1.2
 	github.com/go-audio/audio v0.0.0-20181013203223-7b2a6ca21480
 	github.com/go-audio/wav v0.0.0-20181013172942-de841e69b884
 	github.com/gordonklaus/portaudio v0.0.0-20180817120803-00e7307ccd93
 	github.com/hajimehoshi/go-mp3 v0.1.1
+	github.com/pipelined/vst2 v0.2.0
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.3.0
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dudk/vst2 v0.1.2 h1:a9y4z3flEe53Nfmpkxz8kASj+Co3slxMDUXuMjvA35w=
-github.com/dudk/vst2 v0.1.2/go.mod h1:C4rn6pQAo76vSJpiiteciUqZL5dnwcaZgpIHaC/KbiI=
 github.com/go-audio/aiff v0.0.0-20180403003018-6c3a8a6aff12/go.mod h1:AMSAp6W1zd0koOdX6QDgGIuBDTUvLa2SLQtm7d9eM3c=
 github.com/go-audio/audio v0.0.0-20180206231410-b697a35b5608 h1:PHEBf8t8q21RNXEBzgg15sqaX06CdG1kngmhX+NvQAI=
 github.com/go-audio/audio v0.0.0-20180206231410-b697a35b5608/go.mod h1:6uAu0+H2lHkwdGsAY+j2wHPNPpPoeg5AaEFh9FlA+Zs=
@@ -21,6 +19,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/mattetti/audio v0.0.0-20180912171649-01576cde1f21 h1:Hc1iKlyxNHp3CV59G2E/qabUkHvEwOIJxDK0CJ7CRjA=
 github.com/mattetti/audio v0.0.0-20180912171649-01576cde1f21/go.mod h1:LlQmBGkOuV/SKzEDXBPKauvN2UqCgzXO2XjecTGj40s=
+github.com/pipelined/vst2 v0.2.0 h1:L1XOksMnxEOdqk+tST4HNLYkzqcv+/Ut72DfcB0rWow=
+github.com/pipelined/vst2 v0.2.0/go.mod h1:HolTaYKEQtMEw0m5qSzZjKZ8Ry/3ndhWGJNfGgZXsds=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=

--- a/vst2/vst2.go
+++ b/vst2/vst2.go
@@ -7,7 +7,7 @@ import (
 	"unsafe"
 
 	"github.com/pipelined/phono"
-	"github.com/dudk/vst2"
+	"github.com/pipelined/vst2"
 )
 
 // Processor represents vst2 sound processor


### PR DESCRIPTION
Fix vst2 dependency

closes #52 